### PR TITLE
Hide status and close buttons unless the window has focus

### DIFF
--- a/SidebarDiagnostics/AppBar.xaml
+++ b/SidebarDiagnostics/AppBar.xaml
@@ -13,7 +13,7 @@
         AllowsTransparency="True"
         ShowInTaskbar="False"
         ResizeMode="NoResize"
-        WindowStyle="None">
+        WindowStyle="None" MouseEnter="Window_MouseEnter" MouseLeave="Window_MouseLeave">
     <Window.Background>
         <SolidColorBrush Opacity="{Binding Source={x:Static prop:Settings.Default}, Path=BGOpacity}" Color="{Binding Source={x:Static prop:Settings.Default}, Path=BGColor}" />
     </Window.Background>
@@ -38,7 +38,7 @@
                     VerticalAlignment="Top"
                     Width="14" Height="14"
                     Margin="0,0,10,0"
-                    Style="{StaticResource AppButton}">
+                    Style="{StaticResource AppButton}" Visibility="Hidden">
                 <Path Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}" Stretch="Uniform" Data="M 38,23.5C 38.8643,23.5 39.7109,23.5756 40.5337,23.7206L 42.6275,18.5381L 48.1901,20.787L 46.0964,25.9692C 47.6473,27.0149 48.9851,28.3527 50.0308,29.9036L 55.213,27.8099L 57.4619,33.3725L 52.2794,35.4664C 52.4244,36.2891 52.5,37.1357 52.5,38C 52.5,38.8643 52.4244,39.7109 52.2794,40.5337L 57.4619,42.6275L 55.213,48.1901L 50.0308,46.0964C 49.0795,47.5073 47.8865,48.7418 46.5112,49.7405L 48.7844,54.8462L 43.3041,57.2891L 41.0307,52.1828C 40.0533,52.3906 39.0394,52.5 38,52.5C 37.1357,52.5 36.2891,52.4244 35.4664,52.2794L 33.3725,57.462L 27.8099,55.213L 29.9036,50.0309C 28.3527,48.9851 27.0149,47.6473 25.9691,46.0964L 20.787,48.1901L 18.538,42.6275L 23.7206,40.5336C 23.5756,39.7109 23.5,38.8643 23.5,38C 23.5,37.1357 23.5756,36.2891 23.7206,35.4664L 18.538,33.3725L 20.787,27.8099L 25.9691,29.9036C 26.9205,28.4927 28.1135,27.2582 29.4889,26.2594L 27.2157,21.1537L 32.6959,18.7109L 34.9694,23.8172C 35.9468,23.6094 36.9606,23.5 38,23.5 Z M 38,28C 32.4771,28 28,32.4772 28,38C 28,43.5229 32.4771,48 38,48C 43.5228,48 48,43.5229 48,38C 48,32.4772 43.5228,28 38,28 Z"></Path>
             </Button>
 
@@ -48,7 +48,7 @@
                     VerticalAlignment="Top"
                     Width="14" Height="14"
                     Margin="0,0,0,0"
-                    Style="{StaticResource AppButton}">
+                    Style="{StaticResource AppButton}" Visibility="Hidden">
                 <Path Width="12" Height="12" Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}" Stretch="Uniform" Data="M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z"></Path>
             </Button>
         </StackPanel>

--- a/SidebarDiagnostics/AppBar.xaml.cs
+++ b/SidebarDiagnostics/AppBar.xaml.cs
@@ -475,5 +475,17 @@ namespace SidebarDiagnostics
                 GPU
             }
         }
+
+        private void Window_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            SettingsButton.Visibility = Visibility.Visible;
+            CloseButton.Visibility = Visibility.Visible;
+        }
+
+        private void Window_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            SettingsButton.Visibility = Visibility.Hidden;
+            CloseButton.Visibility = Visibility.Hidden;
+        }
     }
 }


### PR DESCRIPTION
Uses mouse enter and leave to show the buttons.
Will not work touch only devices/control.