### PR TITLE
Use color picker for selecting colors

### DIFF
--- a/SidebarDiagnostics/Settings.xaml
+++ b/SidebarDiagnostics/Settings.xaml
@@ -4,6 +4,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:local="clr-x:Namespace:SidebarDiagnostics"
         xmlns:monitor="clr-namespace:SidebarDiagnostics.Monitor"
         xmlns:convert="clr-namespace:SidebarDiagnostics.Converters"
@@ -129,7 +130,7 @@
                     </DockPanel>
 
                     <Label Grid.Column="0" Grid.Row="1" Content="Background Color" />
-                    <TextBox Grid.Column="1" Grid.Row="1" Text="{Binding Path=BGColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" LostFocus="ColorTextBox_LostFocus" ToolTip="Color of the background as a hex code." />
+                    <xctk:ColorPicker Grid.Column="1" Grid.Row="1" SelectedColor="{Binding Path=BGColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" UsingAlphaChannel="False" ColorMode="ColorCanvas" DisplayColorAndName="True" Margin="0,6,0,6" ShowStandardColors="False" AdvancedButtonHeader="Advanced" AvailableColorsHeader="Colors" StandardButtonHeader="Standard" ToolTip="Color of the background." />
 
                     <Label Grid.Column="0" Grid.Row="2" Content="Background Opacity" />
                     <DockPanel Grid.Column="1" Grid.Row="2">
@@ -141,10 +142,10 @@
                     <ComboBox Grid.Column="1" Grid.Row="3" ItemsSource="{Binding Path=FontSettingItems}" DisplayMemberPath="FontSize" SelectedValue="{Binding Path=FontSetting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="Size of text and icons in the sidebar." />
 
                     <Label Grid.Column="0" Grid.Row="4" Content="Font Color" />
-                    <TextBox Grid.Column="1" Grid.Row="4" Text="{Binding Path=FontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" LostFocus="ColorTextBox_LostFocus" ToolTip="Color of text and icons as a hex code." />
+                    <xctk:ColorPicker Grid.Column="1" Grid.Row="4" SelectedColor="{Binding Path=FontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" UsingAlphaChannel="False" ColorMode="ColorCanvas" DisplayColorAndName="True" Margin="0,6,0,6" ShowStandardColors="False" AdvancedButtonHeader="Advanced" AvailableColorsHeader="Colors" StandardButtonHeader="Standard" ToolTip="Color of text and icons."/>
 
                     <Label Grid.Column="0" Grid.Row="5" Content="Alert Font Color" />
-                    <TextBox Grid.Column="1" Grid.Row="5" Text="{Binding Path=AlertFontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" LostFocus="ColorTextBox_LostFocus" ToolTip="Color of alert text as a hex code." />
+                    <xctk:ColorPicker Grid.Column="1" Grid.Row="5" SelectedColor="{Binding Path=AlertFontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" UsingAlphaChannel="False" ColorMode="ColorCanvas" DisplayColorAndName="True" Margin="0,6,0,6" ShowStandardColors="False" AdvancedButtonHeader="Advanced" AvailableColorsHeader="Colors" StandardButtonHeader="Standard" ToolTip="Color of alert text."/>
 
                     <Label Grid.Column="0" Grid.Row="6" Content="Date Format" />
                     <ComboBox Grid.Column="1" Grid.Row="6" ItemsSource="{Binding Path=DateSettingItems}" DisplayMemberPath="Display" SelectedValue="{Binding Path=DateSetting, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding Path=ShowClock, Mode=OneWay}" ToolTip="Format of the date below the clock." />

--- a/SidebarDiagnostics/Settings.xaml.cs
+++ b/SidebarDiagnostics/Settings.xaml.cs
@@ -66,16 +66,6 @@ namespace SidebarDiagnostics
             ClickThroughCheckbox.IsChecked = false;
         }
 
-        private void ColorTextBox_LostFocus(object sender, RoutedEventArgs e)
-        {
-            TextBox _textbox = (TextBox)sender;
-
-            if (!new Regex("^#[a-fA-F0-9]{6}$").IsMatch(_textbox.Text))
-            {
-                _textbox.Text = "#000000";
-            }
-        }
-
         private void MonitorUp_Click(object sender, RoutedEventArgs e)
         {
             MonitorConfig _row = (MonitorConfig)(sender as Button).DataContext;

--- a/SidebarDiagnostics/SidebarDiagnostics.csproj
+++ b/SidebarDiagnostics/SidebarDiagnostics.csproj
@@ -117,6 +117,30 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.DataGrid, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=2.6.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.6\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/SidebarDiagnostics/packages.config
+++ b/SidebarDiagnostics/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Extended.Wpf.Toolkit" version="2.6" targetFramework="net461" />
   <package id="Hardcodet.NotifyIcon.Wpf" version="1.0.5" targetFramework="net461" />
   <package id="TaskScheduler" version="2.5.12" targetFramework="net461" />
   <package id="VirtualDesktop" version="1.0.3" targetFramework="net461" />


### PR DESCRIPTION
Adds color picker from Extended WPF Toolkit Community Edition for use
when selecting custom colors.

Text fields in the color picker are specifically labelled so they can be
easily identified later for translation.

![image](https://cloud.githubusercontent.com/assets/1089399/12817453/17519480-cb20-11e5-8b10-6f788fc73a21.png)
