### PR TITLE
Adding IPV4 address to display of any currently active network adapter.

### DIFF
--- a/SidebarDiagnostics/Properties/Resources.Designer.cs
+++ b/SidebarDiagnostics/Properties/Resources.Designer.cs
@@ -718,6 +718,15 @@ namespace SidebarDiagnostics.Framework {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to IP.
+        /// </summary>
+        public static string IPAddress {
+            get {
+                return ResourceManager.GetString("IPAddress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please restart the app..
         /// </summary>
         public static string LanguageChangedText {

--- a/SidebarDiagnostics/Properties/Resources.da.resx
+++ b/SidebarDiagnostics/Properties/Resources.da.resx
@@ -405,4 +405,8 @@
     <value>Synlighed</value>
     <comment>Visibility taskbar menu item</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>Adapter IP Address</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.de-CH.resx
+++ b/SidebarDiagnostics/Properties/Resources.de-CH.resx
@@ -989,4 +989,8 @@
     <value>Aktualisierung</value>
     <comment>Title of the update window</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.de.resx
+++ b/SidebarDiagnostics/Properties/Resources.de.resx
@@ -405,4 +405,8 @@
     <value>Sichtbarkeit</value>
     <comment>Visibility taskbar menu item</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.fr.resx
+++ b/SidebarDiagnostics/Properties/Resources.fr.resx
@@ -989,4 +989,8 @@
     <value>Mise à jour</value>
     <comment>Title of the update window</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.ja.resx
+++ b/SidebarDiagnostics/Properties/Resources.ja.resx
@@ -405,4 +405,8 @@
     <value>可視性</value>
     <comment>Visibility taskbar menu item</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.nl.resx
+++ b/SidebarDiagnostics/Properties/Resources.nl.resx
@@ -405,4 +405,8 @@
     <value>Zichtbaarheid</value>
     <comment>Visibility taskbar menu item</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.resx
+++ b/SidebarDiagnostics/Properties/Resources.resx
@@ -997,4 +997,8 @@
     <value>Makes the alert text blink.</value>
     <comment>Settings alert blink tooltip</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>IP</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/Properties/Resources.zh.resx
+++ b/SidebarDiagnostics/Properties/Resources.zh.resx
@@ -989,4 +989,8 @@
     <value>正在升级</value>
     <comment>Title of the update window</comment>
   </data>
+  <data name="IPAddress" xml:space="preserve">
+    <value>【计算机】网际协议。</value>
+    <comment>IP Address of the adapter</comment>
+  </data>
 </root>

--- a/SidebarDiagnostics/SidebarDiagnostics.csproj
+++ b/SidebarDiagnostics/SidebarDiagnostics.csproj
@@ -140,7 +140,7 @@
     </Reference>
     <Reference Include="OpenHardwareMonitorLib, Version=0.7.1.4, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\OpenHardwareMonitor\OpenHardwareMonitorLib.dll</HintPath>
+      <HintPath>..\..\openhardwaremonitor\obj\Debug\OpenHardwareMonitorLib.dll</HintPath>
     </Reference>
     <Reference Include="OxyPlot, Version=1.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">
       <HintPath>..\packages\OxyPlot.Core.1.0.0-unstable2039\lib\net45\OxyPlot.dll</HintPath>


### PR DESCRIPTION
Here is the code to address issue 86, display IP address of the network adapters.  This will display the IPV4 address of any adapter that has an IP assigned.  Adapters without an assigned IP address will be left as originally displayed.

Also, this currently will not dynamically update if the IP address is changed during run-time, it assigns the value at startup and does not check again.  This is something that can be added in the future.

There needs to be some testing of this as the pattern matching I had to do to pair together the monitor information from the performance monitor and network interface namespaces is a little wonky.  I have 4 network adapters on my development machine and it correctly pairs all of them, but it should be further tested before a release to make sure it is robust.  However, the worse case would be no IP address displayed, there should not be the possibility of an exception if there is no match.