### PR TITLE
Check for AMD core chiplet dies temperature

### DIFF
--- a/SidebarDiagnostics/ChangeLog.json
+++ b/SidebarDiagnostics/ChangeLog.json
@@ -3,7 +3,8 @@
     "Version": "Unreleased",
     "Changes": [
       "Russian language support.",
-      "Italian language support."
+      "Italian language support.",
+      "Fix: AMD core chiplet dies temperature (Ryzen Master)"
     ]
   },
   {

--- a/SidebarDiagnostics/Monitoring.cs
+++ b/SidebarDiagnostics/Monitoring.cs
@@ -628,7 +628,9 @@ namespace SidebarDiagnostics.Monitoring
             {
                 ISensor _tempSensor = null;
 
-                if (board != null)
+                _tempSensor = _hardware.Sensors.Where(s => s.SensorType == SensorType.Temperature && s.Name.Contains("CCDs Max (Tdie)")).FirstOrDefault(); // Check for AMD core chiplet dies (CCDs)
+
+                if (board != null && _tempSensor != null)
                 {
                     _tempSensor = board.Sensors.Where(s => s.SensorType == SensorType.Temperature && s.Name.Contains("CPU")).FirstOrDefault();
                 }


### PR DESCRIPTION
This PR checks for AMD core chipset dies temperatures, which is the canonical way of measuring temperature on AMD chips that have this sensor measurement. Following up from issue #187 