### PR TITLE
Bug fix: Culture (language) changing when saving/applying settings.

### DIFF
--- a/SidebarDiagnostics/Settings.cs
+++ b/SidebarDiagnostics/Settings.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using SidebarDiagnostics.Utilities;
 using SidebarDiagnostics.Monitoring;
 using SidebarDiagnostics.Windows;
+using System.Globalization;
 
 namespace SidebarDiagnostics.Framework
 {
@@ -138,6 +139,16 @@ namespace SidebarDiagnostics.Framework
                 _culture = value;
 
                 NotifyPropertyChanged("Culture");
+            }
+        }
+
+        public CultureInfo CultureInfo
+        {
+            get
+            {
+                return string.Equals(_culture, Utilities.Culture.DEFAULT, StringComparison.Ordinal)
+                    ? Utilities.Culture.Default
+                    : new CultureInfo(_culture);
             }
         }
 
@@ -797,7 +808,7 @@ namespace SidebarDiagnostics.Framework
                     return Resources.SettingsDateFormatDisabled;
                 }
 
-                return DateTime.Today.ToString(Format);
+                return DateTime.Today.ToString(Format, Settings.Instance.CultureInfo);
             }
         }
 

--- a/SidebarDiagnostics/Settings.cs
+++ b/SidebarDiagnostics/Settings.cs
@@ -142,16 +142,6 @@ namespace SidebarDiagnostics.Framework
             }
         }
 
-        public CultureInfo CultureInfo
-        {
-            get
-            {
-                return string.Equals(_culture, Utilities.Culture.DEFAULT, StringComparison.Ordinal)
-                    ? Utilities.Culture.Default
-                    : new CultureInfo(_culture);
-            }
-        }
-
         private bool _useAppBar { get; set; } = true;
         
         [JsonProperty]
@@ -808,7 +798,7 @@ namespace SidebarDiagnostics.Framework
                     return Resources.SettingsDateFormatDisabled;
                 }
 
-                return DateTime.Today.ToString(Format, Settings.Instance.CultureInfo);
+                return DateTime.Today.ToString(Format, Culture.CultureInfo);
             }
         }
 

--- a/SidebarDiagnostics/SidebarModel.cs
+++ b/SidebarDiagnostics/SidebarModel.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows.Threading;
 using SidebarDiagnostics.Monitoring;
+using SidebarDiagnostics.Utilities;
 
 namespace SidebarDiagnostics.Models
 {
@@ -126,11 +127,11 @@ namespace SidebarDiagnostics.Models
         {
             DateTime _now = DateTime.Now;
 
-            Time = _now.ToString(Framework.Settings.Instance.Clock24HR ? "H:mm:ss" : "h:mm:ss tt", Framework.Settings.Instance.CultureInfo);
+            Time = _now.ToString(Framework.Settings.Instance.Clock24HR ? "H:mm:ss" : "h:mm:ss tt", Culture.CultureInfo);
 
             if (ShowDate)
             {
-                Date = _now.ToString(Framework.Settings.Instance.DateSetting.Format, Framework.Settings.Instance.CultureInfo);
+                Date = _now.ToString(Framework.Settings.Instance.DateSetting.Format, Culture.CultureInfo);
             }
         }
 

--- a/SidebarDiagnostics/SidebarModel.cs
+++ b/SidebarDiagnostics/SidebarModel.cs
@@ -126,11 +126,11 @@ namespace SidebarDiagnostics.Models
         {
             DateTime _now = DateTime.Now;
 
-            Time = _now.ToString(Framework.Settings.Instance.Clock24HR ? "H:mm:ss" : "h:mm:ss tt");
+            Time = _now.ToString(Framework.Settings.Instance.Clock24HR ? "H:mm:ss" : "h:mm:ss tt", Framework.Settings.Instance.CultureInfo);
 
             if (ShowDate)
             {
-                Date = _now.ToString(Framework.Settings.Instance.DateSetting.Format);
+                Date = _now.ToString(Framework.Settings.Instance.DateSetting.Format, Framework.Settings.Instance.CultureInfo);
             }
         }
 

--- a/SidebarDiagnostics/Utilities.cs
+++ b/SidebarDiagnostics/Utilities.cs
@@ -184,10 +184,10 @@ namespace SidebarDiagnostics.Utilities
 
         public static void SetCurrent(bool init)
         {
-            Resources.Culture = Framework.Settings.Instance.CultureInfo;
+            Resources.Culture = CultureInfo;
 
-            Thread.CurrentThread.CurrentCulture = Framework.Settings.Instance.CultureInfo;
-            Thread.CurrentThread.CurrentUICulture = Framework.Settings.Instance.CultureInfo;
+            Thread.CurrentThread.CurrentCulture = CultureInfo;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo;
 
             if (init)
             {
@@ -209,6 +209,17 @@ namespace SidebarDiagnostics.Utilities
         }
 
         public static CultureInfo Default { get; private set; }
+
+        public static CultureInfo CultureInfo
+        {
+            get
+            {
+                string culture = Framework.Settings.Instance.Culture;
+                return string.Equals(culture, DEFAULT, StringComparison.Ordinal)
+                    ? Default
+                    : new CultureInfo(culture);
+            }
+        }
     }
 
     public class CultureItem

--- a/SidebarDiagnostics/Utilities.cs
+++ b/SidebarDiagnostics/Utilities.cs
@@ -184,12 +184,10 @@ namespace SidebarDiagnostics.Utilities
 
         public static void SetCurrent(bool init)
         {
-            SetCurrent(Framework.Settings.Instance.Culture, init);
-        }
+            Resources.Culture = Framework.Settings.Instance.CultureInfo;
 
-        public static void SetCurrent(string name, bool init)
-        {
-            Thread.CurrentThread.CurrentCulture = Thread.CurrentThread.CurrentUICulture = string.Equals(name, DEFAULT, StringComparison.Ordinal) ? Default : new CultureInfo(name);
+            Thread.CurrentThread.CurrentCulture = Framework.Settings.Instance.CultureInfo;
+            Thread.CurrentThread.CurrentUICulture = Framework.Settings.Instance.CultureInfo;
 
             if (init)
             {


### PR DESCRIPTION
Fixes bug where texts changes back to default when saving/applying settings. App restart was needed to get back to user selected language.

For example, when docking was changed, all the UI texts were changed back to default. (except Time)

Current build:
![before](https://user-images.githubusercontent.com/11576776/97119556-c912b600-1719-11eb-9faa-b1075a86f5d1.gif)

With fix:
![after](https://user-images.githubusercontent.com/11576776/97119560-cca63d00-1719-11eb-96a4-0ff68125ab37.gif)

This was caused because `Resources.Culture` was not set, when changing the language from default. 

Also changed Date/Time formats to culture format.

Here is before and after pic:
![Time_formats](https://user-images.githubusercontent.com/11576776/97119809-67ebe200-171b-11eb-9091-215534ae9e66.png)


Changes:
- Fixed language to be persistent after reloading/changing settings. Probably fixes: #317 
- Time formats changed to culture own format in settings and sidebar.
- Added `CultureInfo` property to Settings, to get selected culture info more easier.
- Removed `Culture.SetCurrent(bool init)`, since it became non used with above changes.
