### PR TITLE
Fixed temperature check for AMD core chiplet dies (CCDs).

### DIFF
--- a/SidebarDiagnostics/Monitoring.cs
+++ b/SidebarDiagnostics/Monitoring.cs
@@ -630,7 +630,7 @@ namespace SidebarDiagnostics.Monitoring
 
                 _tempSensor = _hardware.Sensors.Where(s => s.SensorType == SensorType.Temperature && s.Name.Contains("CCDs Max (Tdie)")).FirstOrDefault(); // Check for AMD core chiplet dies (CCDs)
 
-                if (board != null && _tempSensor != null)
+                if (board != null && _tempSensor == null)
                 {
                     _tempSensor = board.Sensors.Where(s => s.SensorType == SensorType.Temperature && s.Name.Contains("CPU")).FirstOrDefault();
                 }


### PR DESCRIPTION
Bug: The temperature sensor for Ryzen Architecture CPUs "CCDs Max (Tdie)" was being overridden by the generic "CPU" sensor

Context: _tempSensor is just initialized to null before the Ryzen temperature check, which will default to null if it's unsuccessful (e.g. Intel CPU). The problem is: We override the Ryzen CPU temperature reading with the way Intel CPUs measures temperature from _board; we also never use _board on Intel CPUs since _tempSensor will be null. 

How things should work:

1) If AMD Ryzen CPU, use its architecture-specific CPU temperature reading
2) Otherwise, try and read from the _board
3) Lastly, try and read from _hardware

How things currently work:

Right now, on an AMD CPU: We perform 1 successfully, and then immediately override it with 2
Right now, on an Intel CPU, We perform 1 unsuccessfully, we're ineligible for 2, and then we default to 3.

Solution:

My solution should make the above work as intended by only pursuing 2 if 1 fails (right now, 2 is pursued if and only if 1 succeeds, which defeats the purpose of 1 and 2). 

Testing:

I've tested this, and it runs as expected on my 5950x -- temps align with Ryzen Master temps. If someone has an Intel processor, it'd be great to validate that's still WAI.