### PR TITLE
Update Resources.it.resx

### DIFF
--- a/SidebarDiagnostics/Properties/Resources.it.resx
+++ b/SidebarDiagnostics/Properties/Resources.it.resx
@@ -1018,7 +1018,7 @@
     <comment>Title of the sidebar window</comment>
   </data>
   <data name="Time" xml:space="preserve">
-    <value>Tempo</value>
+    <value>Ora</value>
     <comment>Sidebar clock title</comment>
   </data>
   <data name="UpdateErrorFatalText" xml:space="preserve">


### PR DESCRIPTION
In Italian "Tempo" means time, but only when used in a sentence. Alone means "weather". It should be changed as "Ora". The rest of the translation is fine

(I am italian)