### PR TITLE
Ignore ABN_POSCHANGED message if work area didnt change

### DIFF
--- a/SidebarDiagnostics/Windows.cs
+++ b/SidebarDiagnostics/Windows.cs
@@ -1425,6 +1425,7 @@ namespace SidebarDiagnostics.Windows
             {
                 await Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, (Action)(() =>
                 {
+                    _monitorWorkArea = Monitor.GetMonitorFromIndex(Screen).WorkArea;
                     HwndSource.AddHook(AppBarHook);
                 }));
             });
@@ -1482,7 +1483,12 @@ namespace SidebarDiagnostics.Windows
                 switch (wParam.ToInt32())
                 {
                     case APPBARNOTIFY.ABN_POSCHANGED:
-                        SetAppBar();
+                        {
+                            int screen = Framework.Settings.Instance.ScreenIndex;
+                            RECT currentMonitorWa = Monitor.GetMonitorFromIndex(screen).WorkArea;
+                            if (!currentMonitorWa.Equals(_monitorWorkArea))
+                                SetAppBar();
+                        }
                         break;
 
                     case APPBARNOTIFY.ABN_FULLSCREENAPP:
@@ -1529,5 +1535,7 @@ namespace SidebarDiagnostics.Windows
         private int _callbackID { get; set; }
 
         private CancellationTokenSource _cancelReposition { get; set; }
+
+        private RECT _monitorWorkArea { get; set; }
     }
 }


### PR DESCRIPTION
I had a problem where the sidebar would get into an infinite loop of reloading/flickering when using the reserve space setting because every reload would trigger a new ABN_POSCHANGED  message which would trigger another reload...

After every reload/repositioning I save the current work area. We can ignore all ABN_POSCHANGED  messages unless the work area changes.

This PR also prevents unnecessary reloads when clicking on the edge of an unlocked taskbar.

The async delays in `SetAppBar` and `BindAppBar` (`Windows.cs`) might now be obsolete but I wasn't 100% sure. Removing them worked on my machine.