### PR TITLE
Fixed incorrect Spanish translation for "time" string in clock widget

### DIFF
--- a/SidebarDiagnostics/Properties/Resources.es.resx
+++ b/SidebarDiagnostics/Properties/Resources.es.resx
@@ -182,7 +182,7 @@
     <comment>Full name for CPU temp metric</comment>
   </data>
   <data name="Time" xml:space="preserve">
-    <value>Tiempo</value>
+    <value>Hora</value>
     <comment>Sidebar clock title</comment>
   </data>
   <data name="ButtonUpdate" xml:space="preserve">


### PR DESCRIPTION
Just fixing a minor error with the translation of the "Time" word.

It had been originally translated as `tiempo`, which is the generic word for time in Spanish (e.g.: _"It's been a long time"_).

However, in this context it obviously refers to the **time of day** in the clock (e.g.: _"What time is it?"_), which is translated as `hora` in Spanish.